### PR TITLE
added optional `propertyName` argument to `WithRequestHeader`

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,7 @@ namespace MyWebApp
                 .Enrich.WithClientIp()
                 .Enrich.WithCorrelationId()
                 .Enrich.WithRequestHeader("header-name")
+                .Enrich.WithRequestHeader("another-header-name", "some-property-name")
                 .CreateLogger();
         }
 

--- a/README.md
+++ b/README.md
@@ -28,11 +28,11 @@ or in `appsettings.json` file:
   "Serilog": {
     "MinimumLevel": "Debug",
     "Using":  [ "Serilog.Enrichers.ClientInfo" ],
-    "Enrich": [ 
-      "WithClientIp", 
+    "Enrich": [
+      "WithClientIp",
       "WithCorrelationId",
-      { 
-          "Name": "WithRequestHeader", 
+      {
+          "Name": "WithRequestHeader",
           "Args": { "headerName": "User-Agent"}
       }
     ],
@@ -57,7 +57,7 @@ or
   "Serilog": {
     "MinimumLevel": "Debug",
     "Using":  [ "Serilog.Enrichers.ClientInfo" ],
-    "Enrich": [ 
+    "Enrich": [
       {
         "Name": "WithClientIp",
         "Args": {
@@ -83,7 +83,7 @@ or
   "Serilog": {
     "MinimumLevel": "Debug",
     "Using":  [ "Serilog.Enrichers.ClientInfo" ],
-    "Enrich": [ 
+    "Enrich": [
       {
         "Name": "WithCorrelationId",
         "Args": {
@@ -109,7 +109,7 @@ or
   "Serilog": {
     "MinimumLevel": "Debug",
     "Using":  [ "Serilog.Enrichers.ClientInfo" ],
-    "Enrich": [ 
+    "Enrich": [
       {
         "Name": "WithRequestHeader",
         "Args": {
@@ -120,6 +120,13 @@ or
         "Name": "WithRequestHeader",
         "Args": {
           "headerName": "Connection"
+        }
+      },
+      {
+        "Name": "WithRequestHeader",
+        "Args": {
+          "headerName": "Content-Length",
+          "propertyName": "RequestLength"
         }
       }
     ],

--- a/src/Serilog.Enrichers.ClientInfo/Enrichers/ClientHeaderEnricher.cs
+++ b/src/Serilog.Enrichers.ClientInfo/Enrichers/ClientHeaderEnricher.cs
@@ -19,15 +19,17 @@ public class ClientHeaderEnricher : ILogEventEnricher
     private readonly string _headerKey;
     private readonly IHttpContextAccessor _contextAccessor;
 
-    public ClientHeaderEnricher(string headerKey)
-        : this(headerKey, new HttpContextAccessor())
+    public ClientHeaderEnricher(string headerKey, string propertyName)
+        : this(headerKey, propertyName, new HttpContextAccessor())
     {
     }
 
-    internal ClientHeaderEnricher(string headerKey, IHttpContextAccessor contextAccessor)
+    internal ClientHeaderEnricher(string headerKey, string propertyName, IHttpContextAccessor contextAccessor)
     {
         _headerKey = headerKey;
-        _propertyName = headerKey.Replace("-", "");
+        _propertyName = string.IsNullOrWhiteSpace(propertyName) 
+            ? headerKey.Replace("-", "")
+            : propertyName;
         _clientHeaderItemKey = $"Serilog_{headerKey}";
         _contextAccessor = contextAccessor;
     }

--- a/src/Serilog.Enrichers.ClientInfo/Extensions/ClientInfoLoggerConfigurationExtensions.cs
+++ b/src/Serilog.Enrichers.ClientInfo/Extensions/ClientInfoLoggerConfigurationExtensions.cs
@@ -73,11 +73,13 @@ public static class ClientInfoLoggerConfigurationExtensions
     ///   Registers the HTTP request header enricher to enrich logs with the header value.
     /// </summary>
     /// <param name="enrichmentConfiguration">The enrichment configuration.</param>
+    /// <param name="propertyName">The property name of log</param>
     /// <param name="headerName">The header name to log its value</param>
     /// <exception cref="ArgumentNullException">enrichmentConfiguration</exception>
     /// <exception cref="ArgumentNullException">headerName</exception>
     /// <returns>The logger configuration so that multiple calls can be chained.</returns>
-    public static LoggerConfiguration WithRequestHeader(this LoggerEnrichmentConfiguration enrichmentConfiguration, string headerName)
+    public static LoggerConfiguration WithRequestHeader(this LoggerEnrichmentConfiguration enrichmentConfiguration,
+        string headerName, string propertyName = null)
     {
         if (enrichmentConfiguration == null)
         {
@@ -89,6 +91,6 @@ public static class ClientInfoLoggerConfigurationExtensions
             throw new ArgumentNullException(nameof(headerName));
         }
 
-        return enrichmentConfiguration.With(new ClientHeaderEnricher(headerName));
+        return enrichmentConfiguration.With(new ClientHeaderEnricher(propertyName, headerName));
     }
 }


### PR DESCRIPTION
as of now, there is no way to specify the property name for `WithRequestHeader` extension.
it can be easily implemented using code changes in this pull request

```json
{
  "Serilog": {
    "MinimumLevel": "Debug",
    "Using":  [ "Serilog.Enrichers.ClientInfo" ],
    "Enrich": [
      {
        "Name": "WithRequestHeader",
        "Args": {
          "headerName": "Content-Length",
          "propertyName": "RequestLength"
        }
      }
    ],
  }
```