### PR TITLE
Add correlation ID from HTTP response

### DIFF
--- a/src/Serilog.Enrichers.ClientInfo/Enrichers/CorrelationIdEnricher.cs
+++ b/src/Serilog.Enrichers.ClientInfo/Enrichers/CorrelationIdEnricher.cs
@@ -47,10 +47,27 @@ public class CorrelationIdEnricher : ILogEventEnricher
             return;
         }
 
-        var header = httpContext.Request.Headers[_headerKey].ToString();
-        var correlationId = !string.IsNullOrWhiteSpace(header)
-            ? header
-            : (_addValueIfHeaderAbsence ? Guid.NewGuid().ToString() : null);
+        var requestHeader = httpContext.Request.Headers[_headerKey];
+        var responseHeader = httpContext.Response.Headers[_headerKey];
+        
+        string correlationId;
+        
+        if (!string.IsNullOrWhiteSpace(requestHeader))
+        {
+            correlationId = requestHeader;
+        }
+        else if (!string.IsNullOrWhiteSpace(responseHeader))
+        {
+            correlationId = responseHeader;
+        }
+        else if (_addValueIfHeaderAbsence)
+        {
+            correlationId = Guid.NewGuid().ToString();
+        }
+        else
+        {
+            correlationId = null;
+        }
 
         var correlationIdProperty = new LogEventProperty(PropertyName, new ScalarValue(correlationId));
         logEvent.AddOrUpdateProperty(correlationIdProperty);


### PR DESCRIPTION
## Summary

This change ensures that the `CorrelationIdEnricher` also checks the HTTP response for an existing correlation ID before potentially generating a new one.

## Rationale

If a separate middleware is used that generates correlation IDs and adds them to the HTTP response (if no ID is provided by the HTTP request), the `CorrelationIdEnricher` would not be aware of this. Instead of using the correlation ID provided by the HTTP response it would either generate a new ID or omit it, leading to a discrepancy between the HTTP response header and the log message.